### PR TITLE
Allow for multiple chromecasts to be set up in the same browser session

### DIFF
--- a/public/js/gscreen.js
+++ b/public/js/gscreen.js
@@ -541,6 +541,7 @@
         return castAway.connect(function (err, s) {
           if (err)
             return console.log('ERR', err);
+          s.session.leave();
           session = s;
           return $scope.$apply(function () {
             return $scope.chromecast.name = session.session.receiver.friendlyName;

--- a/src/client/controllers/chromecast-form.coffee
+++ b/src/client/controllers/chromecast-form.coffee
@@ -21,6 +21,7 @@ angular.module("GScreen").controller "ChromecastForm", ($scope, $routeParams, $l
   connect = ->
     castAway.connect (err, s) ->
       return console.log "ERR", err if err
+      s.session.leave()
       session = s
       $scope.$apply ->
         $scope.chromecast.name = session.session.receiver.friendlyName


### PR DESCRIPTION
Background: I have multiple TV's each being driven by a chromecast. Occasionally after a power failure or some other mishap, some or all disconnect, so I have to go back to greenscreen to reconnect each of the chromecasts. An upgrade to the chromecast extension within the past year or so has caused the behavior given below. I can only set up one at a time and then have to disconnect from my wifi for a few minutes before I can reconnect and set up subsequent chromecasts.

Current behavior: Connect to one chromecast. As cast session is created. Connect to a second chromecast. The same session is used, which causes the first chromecast to disconnect. The second chromecast finishes connecting.

Solution: Leave (but not stop) the current cast session, so subsequent chromecasts can be connected using new sessions.

Proposed behavior: Connect to one chromecast. As cast session is created and then leave() is called on that session. Connect to a second chromecast. A new session is used, since leave() was called on the old session, allowing for a new session to be created. The second chromecast finishes connecting. Both chromecasts are connected and set up subsequent chromecasts can be connected.